### PR TITLE
Resolve S3 error: "Please use AWS4-HMAC-SHA256"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
   && apt-get install -y duplicity python-setuptools \
   && apt-get install -y \
     python-boto python-swiftclient python-pexpect openssh-client \
+  && easy_install -U boto \
   && rm -rf /var/apt/lists/*
 
 VOLUME [ "/root/.cache/duplicity" ]


### PR DESCRIPTION
With the current docker-duplicity image used by docker-conplicity this error is generated in S3 version 4 regions: 
`The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256`

According to this duplicity ticket https://bugs.launchpad.net/duplicity/+bug/1407966 the 2.3.8 boto version in this image should work but I still got the error. I resolved it by upgrading boto in this image to the latest version and now it works correctly.